### PR TITLE
fix icon in package theme

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -1,11 +1,8 @@
-
 module.exports = () => {
-
   return {
     '@primary-color': '#1DA57A',
     '@link-color': '#1DA57A',
     '@border-radius-base': '2px',
-    '@icon-url': '/assets/fonts/iconfont/iconfont'
+    '@icon-url': '"/assets/fonts/iconfont/iconfont"',
   };
-
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,21 +7,32 @@ module.exports = function (webpackConfig, env) {
   webpackConfig.babel.plugins.push('transform-runtime');
   webpackConfig.babel.plugins.push(['import', {
     libraryName: 'antd',
-    style: 'css'  // if true, use less
+    style: true,
   }]);
 
   // Enable hmr for development.
   if (env === 'development') {
     webpackConfig.babel.plugins.push('dva-hmr');
   }
-
+  
+  // CSS Modules Support.
   // Parse all less files as css module.
-  webpackConfig.module.loaders.forEach(function (loader, index) {
+  webpackConfig.module.loaders.forEach(function(loader, index) {
     if (typeof loader.test === 'function' && loader.test.toString().indexOf('\\.less$') > -1) {
-      loader.test = /\.dont\.exist\.file/;
+      loader.include = /node_modules/;
+      loader.test = /\.less$/;
     }
     if (loader.test.toString() === '/\\.module\\.less$/') {
+      loader.exclude = /node_modules/;
       loader.test = /\.less$/;
+    }
+    if (typeof loader.test === 'function' && loader.test.toString().indexOf('\\.css$') > -1) {
+      loader.include = /node_modules/;
+      loader.test = /\.css$/;
+    }
+    if (loader.test.toString() === '/\\.module\\.css$/') {
+      loader.exclude = /node_modules/;
+      loader.test = /\.css$/;
     }
   });
 


### PR DESCRIPTION
ant-design/antd-init#133

1. `'@icon-url': '/assets/fonts/iconfont/iconfont',` should be `'@icon-url': '"/assets/fonts/iconfont/iconfont"'`. ⚠⚠⚠
2. `babel-plugin-import` use `style: true`.
3. parse all less as css-modules.
